### PR TITLE
Fix README.md: TranslationsByLocale is no longer an exposed type

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ import 'package:i18n_extension/io/import.dart';
 import 'package:i18n_extension/i18n_extension.dart';
 
 class MyI18n {
-  static TranslationsByLocale translations = Translations.byLocale("en");
+  static dynamic translations = Translations.byLocale("en");
 
   static Future<void> loadTranslations() async {
     translations +=


### PR DESCRIPTION
The code snippet in README.md is no longer functional. This PR fixes it.